### PR TITLE
Combat rogue energy fix

### DIFF
--- a/modules/energytick.lua
+++ b/modules/energytick.lua
@@ -1,5 +1,7 @@
 local function getAdjustedTickTimer()
   local adjustedEnergyTick = 2
+
+  -- Check rogue talents and compute energy tick timing reduction for Combat spec (1.18.0 Blade Rush Talent)
   if UnitClass("player") == "Rogue" then
     local _, _, _, _, currRank = GetTalentInfo(2, 16)
     local bladeRushRank = currRank or 0
@@ -58,8 +60,6 @@ pfUI:RegisterModule("energytick", "vanilla:tbc", function()
       if this.lastMana then
         diff = this.currentMana - this.lastMana
       end
-
-      -- Check rogue talents and compute energy tick timing reduction for Combat spec (1.18.0 Blade Rush Talent)
 
       if this.mode == "MANA" and diff < 0 then
         this.target = 5


### PR DESCRIPTION
Added calculation for the energy tick timing reduction provided by the [Blade Rush Talent](https://database.turtlecraft.gg/?spell=52508) added for the Rogue Combat spec in 1.18.0.

The code is ~~shamelessly stolen~~ adapted from @Wierdthing https://github.com/wierdthing/RogueFocus, and tested with combat spec, non-combat spec (assassination, but should works just as well with a feral druid) and a priest to check that the mana timer has not been impacted.

P.S.: Sorry for the auto-formatting, I can manually revert that if you prefer.