### PR TITLE
Fix some Turtle WoW skins

### DIFF
--- a/modules/turtle-wow.lua
+++ b/modules/turtle-wow.lua
@@ -303,10 +303,12 @@ pfUI:RegisterModule("turtle-wow", "vanilla", function ()
         -- break if theres nothing left to do
         if initialized then return end
 
+        local _, scaled_border = GetBorderSize()
+
         -- adjust ui positions
         SkinTab(InspectFrameTab3)
         InspectFrameTab3:ClearAllPoints()
-        InspectFrameTab3:SetPoint("LEFT", InspectFrameTab2, "RIGHT", GetBorderSize()*2 + 1, 0)
+        InspectFrameTab3:SetPoint("LEFT", InspectFrameTab2, "RIGHT", scaled_border*2 + 1, 0)
         TWTalentFrameTab1:SetPoint("TOPLEFT", TWTalentFrameScrollFrame, "TOPLEFT", 2, TWTalentFrameTab1:GetHeight() + 4)
 
         -- reload text position


### PR DESCRIPTION
# Fix Turtle WoW skins

This PR fixes some pfUI skins for Turtle WoW

## Character menu title dropdown

This fixes the character menu title dropdown not being skinned properly.

A relatively straight-forward fix.
The dropdown was renamed in FrameXML from 'TWTitles' to 'PaperDollFrameTitlesDropdown'.

The fix is implemented in the turtle-wow module.

## Inspect frame talent tab button positioning

Fixes inspect frame talent tab button positioning on higher screen resolutions by using the scaled border size.

## Turtle WoW skin locations

Question is, should all custom Turtle WoW skins, abilities and behaviour remain in the turtle-wow module?
