### PR TITLE
Add Find Trees to tracking menu

### DIFF
--- a/modules/tracking.lua
+++ b/modules/tracking.lua
@@ -18,7 +18,8 @@ pfUI:RegisterModule("tracking", "vanilla", function ()
     any = {
       "Racial_Dwarf_FindTreasure", -- Find Treasure
       "Spell_Nature_Earthquake", -- Find Minerals
-      "INV_Misc_Flower_02" -- Find Herbs
+      "INV_Misc_Flower_02", -- Find Herbs
+      "inv_tradeskillitem_03" -- Find Trees (TurtleWow Survival)
     },
     HUNTER = {
       "Ability_Tracking", -- Track Beasts, 4+


### PR DESCRIPTION
Adds the survival Find Trees to the tracking menu options. 

Not sure if we should do a check for if TURTLE_WOW_VERSION exists, or just leave it since it would be skipped on other servers anyway.