### PR TITLE
Update nameplates.lua - raid icons always visible

### DIFF
--- a/modules/nameplates.lua
+++ b/modules/nameplates.lua
@@ -751,7 +751,7 @@ nameplates:RegisterEvent("ZONE_CHANGED_NEW_AREA")
     nameplate.level = nameplate:CreateFontString(nil, "OVERLAY")
     nameplate.level:SetPoint("RIGHT", nameplate.health, "LEFT", -3, 0)
 
-    nameplate.raidicon:SetParent(nameplate.health)
+    nameplate.raidicon:SetParent(plate)
     nameplate.raidicon:SetDrawLayer("OVERLAY")
     nameplate.raidicon:SetTexture(pfUI.media["img:raidicons"])
 


### PR DESCRIPTION

<img width="660" height="441" alt="20260323 raid icon persist example" src="https://github.com/user-attachments/assets/a4a37266-de1d-44e1-8e66-73db6edc315a" />


Changing parent from nameplate.health to plate allows raid icons to be shown even when nameplate health bar isn't shown. 

Particularly useful if you have friendly nameplate healthbars disabled and friendlies have raid marks (e.g. tanks, marked player to stack on, etc)