### PR TITLE
Update castbar.lua

### DIFF
--- a/modules/castbar.lua
+++ b/modules/castbar.lua
@@ -252,6 +252,7 @@ pfUI:RegisterModule("castbar", "vanilla", function ()
       else
         this.bar:SetMinMaxValues(1,100)
         this.bar:SetValue(100)
+        this.lastMax = nil
         this.fadeout = 1
         this.delay = 0
         this.itemIconApplied = nil


### PR DESCRIPTION
Fixed issue were the same duration spell wouldn't update progress bar properly.  Reset so the next cast reapplies SetMinMaxValues(0, duration); otherwise same-duration casts