### PR TITLE
Fix Track Elementals showing wrong spell

### DIFF
--- a/modules/tracking.lua
+++ b/modules/tracking.lua
@@ -154,7 +154,7 @@ pfUI:RegisterModule("tracking", "vanilla", function ()
         -- scan class specific tracking icons
         if knownTrackingSpellTextures[playerClass] then
           for _, texture in pairs(knownTrackingSpellTextures[playerClass]) do
-            if spellTexture and strfind(spellTexture, texture) and not state.spells[texture] then
+            if spellTexture and strfind(spellTexture, texture .. "$") and not state.spells[texture] then
                 state.spells[texture] = {
                   index = spellIndex,
                   name = GetSpellName(spellIndex, BOOKTYPE_SPELL),


### PR DESCRIPTION
If you have Water Waveling companion in your spell book, the tracking drop down is showing that instead of Track Elementals because they have similar texture names (Spell_Frost_SummonWaterElemental and Spell_Frost_SummonWaterElemental_2).

Fix: Include end of string in the name matching